### PR TITLE
Fixed `detinfo::DetectorPropertiesStandard` `Efield` parameter description

### DIFF
--- a/lardataalg/DetectorInfo/DetectorPropertiesStandard.h
+++ b/lardataalg/DetectorInfo/DetectorPropertiesStandard.h
@@ -44,8 +44,8 @@ namespace detinfo {
 
       fhicl::Sequence<double> Efield{
         Name("Efield"),
-        Comment("electric field in front of each wire plane (the last one is "
-                "the big one!) [kV/cm]")};
+        Comment("electric field in front of each wire plane (toward cathode; the first one is "
+                "the main TPC drift volume) [kV/cm]")};
 
       fhicl::Atom<double> Electronlifetime{Name("Electronlifetime"),
                                            Comment("electron lifetime in liquid argon [us]")};


### PR DESCRIPTION
The meaning of the `Efield` parameter is better described in [Doxygen documentation of its C++ interface](https://nusoft.fnal.gov/larsoft/doxsvn/html/classdetinfo_1_1DetectorProperties.html#a6ea34d73e6eeade3cc28c54fad5cf4ec) (in fact in my understanding the plane numbering is now strongly determined and the warning in the description is somehow outdated, although not harmful).
The statement "last is the big one" is incorrect, since "the big one" is the first one (index `0`).
The new wording should be clearer and correct...er.

This is a documentation commit that should take low priority and be opportunistically scheduled for merge joint with other commits (i.e. not worth a new version by itself).